### PR TITLE
feat: add repository and homepage fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "packageManager": "pnpm@9.1.4",
   "description": "Storyblok RichText Resolver",
   "author": "Alvaro Saburido <hola@alvarosaburido.dev> (https://github.com/alvarosabu/)",
+  "homepage": "https://github.com/storyblok/richtext#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/storyblok/richtext.git" 
+  },
   "license": "MIT",
   "keywords": [
     "storyblok",


### PR DESCRIPTION
npmjs.com uses these fields to directly link to the repo from the package detail page