### PR TITLE
feat: add table support to rich text resolver

### DIFF
--- a/playground/vanilla/src/main.ts
+++ b/playground/vanilla/src/main.ts
@@ -400,6 +400,268 @@ import StoryblokClient from 'storyblok-js-client';
   ],
 }; */
 
+/* const tableDoc: StoryblokRichTextDocumentNode = {
+  type: 'doc',
+  content: [
+    {
+      type: 'table',
+      content: [
+        {
+          type: 'tableRow',
+          content: [
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'Header 1',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'Header  2',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'Header 3',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'tableRow',
+          content: [
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R1C1',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R1C2',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R1C3',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'tableRow',
+          content: [
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R2C1',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R2C2',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R2C3',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: 'tableRow',
+          content: [
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R3C1',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R3C2',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: 'tableCell',
+              attrs: {
+                colspan: 1,
+                rowspan: 1,
+                colwidth: null,
+              },
+              content: [
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      text: 'R3C3',
+                      type: 'text',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'paragraph',
+    },
+  ],
+}; */
+
 // Storyblok
 
 const client = new StoryblokClient({

--- a/src/richtext.test.ts
+++ b/src/richtext.test.ts
@@ -345,6 +345,210 @@ describe('richtext', () => {
       const html = render(quote as unknown as StoryblokRichTextNode<string>);
       expect(html).toBe('<blockquote><p>Quote</p></blockquote>');
     });
+
+    it('should render a table', async () => {
+      const { render } = richTextResolver({});
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Cell 1',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Cell 2',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table><tr><td><p>Cell 1</p></td><td><p>Cell 2</p></td></tr></table>');
+    });
+
+    it('should render a table with colspan and rowspan', async () => {
+      const { render } = richTextResolver({});
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 2,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Merged Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Cell 1',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Cell 2',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table><tr><td colspan="2"><p>Merged Cell</p></td></tr><tr><td><p>Cell 1</p></td><td><p>Cell 2</p></td></tr></table>');
+    });
+
+    it('should render a table with colwidth', async () => {
+      const { render } = richTextResolver({});
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: 200,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Fixed Width Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table><tr><td style="width: 200px;"><p>Fixed Width Cell</p></td></tr></table>');
+    });
+
+    it('should render a table with keyed resolvers', async () => {
+      const { render } = richTextResolver({
+        keyedResolvers: true,
+      });
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Cell 1',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table key="table-5"><tr key="tr-5"><td key="td-5"><p key="p-5">Cell 1</p></td></tr></table>');
+    });
   });
 
   describe('textTypes & MarksTypes', () => {

--- a/src/richtext.test.ts
+++ b/src/richtext.test.ts
@@ -549,6 +549,176 @@ describe('richtext', () => {
       const html = render(table as StoryblokRichTextNode<string>);
       expect(html).toBe('<table key="table-5"><tr key="tr-5"><td key="td-5"><p key="p-5">Cell 1</p></td></tr></table>');
     });
+
+    it('should render a table cell with background color', async () => {
+      const { render } = richTextResolver({});
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                  backgroundColor: '#F11F1F',
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Colored Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table><tr><td style="background-color: #F11F1F;"><p>Colored Cell</p></td></tr></table>');
+    });
+
+    it('should render a table cell with both width and background color', async () => {
+      const { render } = richTextResolver({});
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: 200,
+                  backgroundColor: '#F11F1F',
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Styled Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table><tr><td style="width: 200px; background-color: #F11F1F;"><p>Styled Cell</p></td></tr></table>');
+    });
+
+    it('should render a table with header cells', async () => {
+      const { render } = richTextResolver({});
+      const table = {
+        type: 'table',
+        content: [
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableHeader',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                  backgroundColor: '#F5F5F5',
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Header Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'tableHeader',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Another Header',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'tableRow',
+            content: [
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Regular Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: 'tableCell',
+                attrs: {
+                  colspan: 1,
+                  rowspan: 1,
+                  colwidth: null,
+                },
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        text: 'Another Cell',
+                        type: 'text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const html = render(table as StoryblokRichTextNode<string>);
+      expect(html).toBe('<table><tr><th style="background-color: #F5F5F5;"><p>Header Cell</p></th><th><p>Another Header</p></th></tr><tr><td><p>Regular Cell</p></td><td><p>Another Cell</p></td></tr></table>');
+    });
   });
 
   describe('textTypes & MarksTypes', () => {

--- a/src/richtext.ts
+++ b/src/richtext.ts
@@ -214,6 +214,52 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
     }) as T;
   };
 
+  const tableResolver: StoryblokRichTextNodeResolver<T> = (node: StoryblokRichTextNode<T>): T => {
+    const attributes: Record<string, unknown> = {
+    };
+
+    if (keyedResolvers) {
+      attributes.key = `table-${currentKey}`;
+    }
+
+    return renderFn('table', attributes, node.children) as T;
+  };
+
+  const tableRowResolver: StoryblokRichTextNodeResolver<T> = (node: StoryblokRichTextNode<T>): T => {
+    const attributes: Record<string, unknown> = {};
+
+    if (keyedResolvers) {
+      attributes.key = `tr-${currentKey}`;
+    }
+
+    return renderFn('tr', attributes, node.children) as T;
+  };
+
+  const tableCellResolver: StoryblokRichTextNodeResolver<T> = (node: StoryblokRichTextNode<T>): T => {
+    const { colspan, rowspan, colwidth, ...rest } = node.attrs || {};
+    const attributes = {
+      ...rest,
+    };
+
+    if (colspan > 1) {
+      attributes.colspan = colspan;
+    }
+
+    if (rowspan > 1) {
+      attributes.rowspan = rowspan;
+    }
+
+    if (colwidth) {
+      attributes.style = `width: ${colwidth}px;`;
+    }
+
+    if (keyedResolvers) {
+      attributes.key = `td-${currentKey}`;
+    }
+
+    return renderFn('td', cleanObject(attributes), node.children) as T;
+  };
+
   const mergedResolvers = new Map<StoryblokRichTextNodeTypes, StoryblokRichTextNodeResolver<T>>([
     [BlockTypes.DOCUMENT, nodeResolver('')],
     [BlockTypes.HEADING, headingResolver],
@@ -241,6 +287,9 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
     [MarkTypes.SUPERSCRIPT, markResolver('sup')],
     [MarkTypes.SUBSCRIPT, markResolver('sub')],
     [MarkTypes.HIGHLIGHT, markResolver('mark')],
+    [BlockTypes.TABLE, tableResolver],
+    [BlockTypes.TABLE_ROW, tableRowResolver],
+    [BlockTypes.TABLE_CELL, tableCellResolver],
     ...(Object.entries(resolvers).map(([type, resolver]) => [type as StoryblokRichTextNodeTypes, resolver])) as unknown as Array<[StoryblokRichTextNodeTypes, StoryblokRichTextNodeResolver<T>]>,
   ]);
 

--- a/src/richtext.ts
+++ b/src/richtext.ts
@@ -236,7 +236,7 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
   };
 
   const tableCellResolver: StoryblokRichTextNodeResolver<T> = (node: StoryblokRichTextNode<T>): T => {
-    const { colspan, rowspan, colwidth, ...rest } = node.attrs || {};
+    const { colspan, rowspan, colwidth, backgroundColor, ...rest } = node.attrs || {};
     const attributes = {
       ...rest,
     };
@@ -249,8 +249,19 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
       attributes.rowspan = rowspan;
     }
 
+    // Handle both width and background color in style attribute
+    const styles: string[] = [];
+
     if (colwidth) {
-      attributes.style = `width: ${colwidth}px;`;
+      styles.push(`width: ${colwidth}px;`);
+    }
+
+    if (backgroundColor) {
+      styles.push(`background-color: ${backgroundColor};`);
+    }
+
+    if (styles.length > 0) {
+      attributes.style = styles.join(' ');
     }
 
     if (keyedResolvers) {
@@ -258,6 +269,42 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
     }
 
     return renderFn('td', cleanObject(attributes), node.children) as T;
+  };
+
+  const tableHeaderResolver: StoryblokRichTextNodeResolver<T> = (node: StoryblokRichTextNode<T>): T => {
+    const { colspan, rowspan, colwidth, backgroundColor, ...rest } = node.attrs || {};
+    const attributes = {
+      ...rest,
+    };
+
+    if (colspan > 1) {
+      attributes.colspan = colspan;
+    }
+
+    if (rowspan > 1) {
+      attributes.rowspan = rowspan;
+    }
+
+    // Handle both width and background color in style attribute
+    const styles: string[] = [];
+
+    if (colwidth) {
+      styles.push(`width: ${colwidth}px;`);
+    }
+
+    if (backgroundColor) {
+      styles.push(`background-color: ${backgroundColor};`);
+    }
+
+    if (styles.length > 0) {
+      attributes.style = styles.join(' ');
+    }
+
+    if (keyedResolvers) {
+      attributes.key = `th-${currentKey}`;
+    }
+
+    return renderFn('th', cleanObject(attributes), node.children) as T;
   };
 
   const mergedResolvers = new Map<StoryblokRichTextNodeTypes, StoryblokRichTextNodeResolver<T>>([
@@ -290,6 +337,7 @@ export function richTextResolver<T>(options: StoryblokRichTextOptions<T> = {}) {
     [BlockTypes.TABLE, tableResolver],
     [BlockTypes.TABLE_ROW, tableRowResolver],
     [BlockTypes.TABLE_CELL, tableCellResolver],
+    [BlockTypes.TABLE_HEADER, tableHeaderResolver],
     ...(Object.entries(resolvers).map(([type, resolver]) => [type as StoryblokRichTextNodeTypes, resolver])) as unknown as Array<[StoryblokRichTextNodeTypes, StoryblokRichTextNodeResolver<T>]>,
   ]);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,9 @@ export enum BlockTypes {
   IMAGE = 'image',
   EMOJI = 'emoji',
   COMPONENT = 'blok',
+  TABLE = 'table',
+  TABLE_ROW = 'tableRow',
+  TABLE_CELL = 'tableCell',
 }
 
 export enum MarkTypes {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export enum BlockTypes {
   TABLE = 'table',
   TABLE_ROW = 'tableRow',
   TABLE_CELL = 'tableCell',
+  TABLE_HEADER = 'tableHeader',
 }
 
 export enum MarkTypes {


### PR DESCRIPTION
Implement table rendering functionality in the rich text resolver, including:
- Support for table, table row, and table cell node types
- Handling of colspan, rowspan, and colwidth attributes
- Adding optional keyed resolvers for table elements
- Extending types to include new table-related node types
- Adding comprehensive test cases for table rendering
