### PR TITLE
feat: expose original and merged resolvers for external callback

### DIFF
--- a/playground/vanilla/src/main.ts
+++ b/playground/vanilla/src/main.ts
@@ -1,6 +1,5 @@
 import './style.css';
-import { MarkTypes, richTextResolver, type StoryblokRichTextNode, type StoryblokRichTextOptions } from '@storyblok/richtext';
-import StoryblokClient from 'storyblok-js-client';
+import { BlockTypes, richTextResolver, type StoryblokRichTextNode, type StoryblokRichTextOptions } from '@storyblok/richtext';
 
 /* const test = {
   type: 'doc',
@@ -30,7 +29,7 @@ import StoryblokClient from 'storyblok-js-client';
     },
   ],
 }; */
-/* const doc: StoryblokRichTextDocumentNode = {
+const doc: StoryblokRichTextDocumentNode = {
   type: 'doc',
   content: [
     {
@@ -398,7 +397,7 @@ import StoryblokClient from 'storyblok-js-client';
       },
     },
   ],
-}; */
+};
 
 /* const tableDoc: StoryblokRichTextDocumentNode = {
   type: 'doc',
@@ -664,20 +663,20 @@ import StoryblokClient from 'storyblok-js-client';
 
 // Storyblok
 
-const client = new StoryblokClient({
+/* const client = new StoryblokClient({
   accessToken: import.meta.env.VITE_STORYBLOK_TOKEN,
-});
+}); */
 
-const story = await client.get('cdn/stories/home', {
+/* const story = await client.get('cdn/stories/home', {
   version: 'draft',
 });
 
-const docFromStory = story.data.story.content.richtext;
+const docFromStory = story.data.story.content.richtext; */
 
 const options: StoryblokRichTextOptions<string> = {
   resolvers: {
-    [MarkTypes.LINK]: (node: StoryblokRichTextNode<string>) => {
-      return `<button href="${node.attrs?.href}" target="${node.attrs?.target}">${node.children}</button>`;
+    [BlockTypes.HEADING]: (node: StoryblokRichTextNode<string>, ctx) => {
+      return ctx.originalResolvers.get(BlockTypes.HEADING)?.(node, ctx) || '';
     },
   },
   optimizeImages: {
@@ -696,7 +695,7 @@ const options: StoryblokRichTextOptions<string> = {
   },
 };
 
-const html = richTextResolver(options).render(docFromStory);
+const html = richTextResolver(options).render(doc);
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div class="this-div-is-on-purpose">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,14 @@ export interface StoryblokRichTextContext<T = string> {
    * @param children - Optional children content
    */
   render: (tag: string, attrs?: Record<string, any>, children?: T) => T;
+  /**
+   * Original resolvers map
+   */
+  originalResolvers: Map<StoryblokRichTextNodeTypes, StoryblokRichTextNodeResolver<T>>;
+  /**
+   * Merged resolvers map
+   */
+  mergedResolvers: Map<StoryblokRichTextNodeTypes, StoryblokRichTextNodeResolver<T>>;
 }
 
 /**


### PR DESCRIPTION
This PR exposes original and merged resolvers to the external callback, enabling flexible and powerful overrides:

Replace all `{@Storyblok}` occurrences on text with a magic link component:

```ts
const magicLinkResolver = (node: { text?: string }, ctx): VNode => {
  if (!node.text) return ctx.originalResolvers(TextTypes.TEXT)(node, ctx)
  
  const magicLinkRegex = /{@([^}]+)}/g;
  const parts = node.text.split(magicLinkRegex);
  
  if (parts.length <= 1) return ctx.render(node);

  return h('span', {}, parts.map((part: string, index: number) => {
    if (index % 2 === 0) return part;
    
    return h(MagicLink, {
      label: part,
    });
  }));
};

const { render } = useStoryblokRichText({
    resolvers: {
      ...(resolvers as StoryblokRichTextResolvers<VNode>),
       [TextTypes.TEXT]: magicLinkResolver
    },
  });
```